### PR TITLE
Declared usage of pint inside session.py

### DIFF
--- a/pyhaystack/client/session.py
+++ b/pyhaystack/client/session.py
@@ -53,7 +53,8 @@ class HaystackSession(object):
 
     def __init__(self, uri, api_dir, grid_format=hszinc.MODE_ZINC,
                 http_client=sync.SyncHttpClient, http_args=None,
-                tagging_model=HaystackTaggingModel, log=None):
+                tagging_model=HaystackTaggingModel, log=None,
+                pint=False):
         """
         Initialise a base Project Haystack session handler.
 
@@ -64,6 +65,9 @@ class HaystackSession(object):
         :param http_args: Optional HTTP client arguments to configure.
         :param tagging_model: Entity Tagging model in use.
         :param log: Logging object for reporting messages.
+        :param pint: Configure hszinc to use basic quantity or Pint Quanity
+        
+        See : https://pint.readthedocs.io/ for details about pint
         """
         if log is None:
             log = logging.getLogger('pyhaystack.client.%s' \
@@ -72,6 +76,9 @@ class HaystackSession(object):
 
         if http_args is None:
             http_args = {}
+        
+        #Configure hszinc to use pint or not for Quantity definition
+        self.config_pint(pint)
 
         if grid_format not in (hszinc.MODE_ZINC, hszinc.MODE_JSON):
             raise ValueError('Unrecognised grid format %s' % grid_format)
@@ -536,3 +543,10 @@ class HaystackSession(object):
         """
         raise NotImplementedError('To be implemented in %s' % \
                 self.__class__.__name__)
+
+    def config_pint(self, value=False):
+        if value:
+            self._use_pint = True
+        else:
+            self._use_pint = False
+        hszinc.use_pint(self._use_pint)

--- a/pyhaystack/info.py
+++ b/pyhaystack/info.py
@@ -12,6 +12,6 @@ Project Haystack is an open source initiative to streamline working with data fr
 
 __author__ = 'Christian Tremblay, Stuart J. Longland, @sudo-Whateverman, Igor'
 __author_email__ = 'christian.tremblay@servisys.com'
-__version__ = '0.74.0'
+__version__ = '0.74.1'
 __license__ = 'LGPL'
 __copyright__ = "Christian Tremblay / SERVISYS inc. | Stuart J. Longland / VRT | 2016"


### PR DESCRIPTION
Test code working on running server :
```
session.config_pint(True)
room_temp_sensors = session.find_entity(filter_expr='sensor and zone and temp').result
room_temp_sensors['S.SERVISYS.Bureau-Christian.ZN~2dT'].tags['curVal'].to('degF')
```

To get back to basicQuantity simply use :
```
session.config_pint(False)
```

Signed-off-by: Christian Tremblay, ing. <christian.tremblay@servisys.com>