### PR TITLE
client.http.base: Send Content-Length as a string.

### DIFF
--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -223,7 +223,7 @@ class HTTPClient(object):
                 body_size = len(body)
 
             if body_size is not False:
-                headers['Content-Length'] = body_size
+                headers['Content-Length'] = str(body_size)
 
             if body_type is not None:
                 headers['Content-Type'] = body_type


### PR DESCRIPTION
`requests` tries to do a regex match or similar on the values of
headers, and this requires the input to be a string.  It barfs when you
give it an `int`.