### PR TITLE
client.ops.vendor.widesky: Version detection tweaks

### DIFF
--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -207,10 +207,15 @@ class WideSkyHasFeaturesOperation(HasFeaturesOperation):
             return res
 
 
-        # Get the WideSky version
-        ver = self._about_data['productVersion']
+        # Get the WideSky version, preferring moduleVersion over productVersion
+        ver = self._about_data.get('moduleVersion',
+                self._about_data['productVersion'])
         for feature in self._features:
             if feature in (HaystackSession.FEATURE_HISREAD_MULTI,
                     HaystackSession.FEATURE_HISWRITE_MULTI):
-                res[feature] = semver.match(ver, '>=0.5.0')
+                try:
+                    res[feature] = semver.match(ver, '>=0.5.0')
+                except ValueError:
+                    # Unrecognised version string
+                    return res
         return res


### PR DESCRIPTION
We've had to re-jig some of our interface around, so `productVersion` now reports the platform release (which is of the form YY.MM; like Ubuntu) and `moduleVersion` now carries the Semantic versioning code.  This tweaks the feature detection code to first look for `moduleVersion` and only fall back to `productVersion` if `moduleVersion` isn't present.

Changes:
- Handle non-semver version string
- Prefer moduleVersion over productVersion; newer versions will use this
  over productVersion which will be the "WideSky release".  (like
  Ubuntu's; 16.04.)