### PR TITLE
Fix HTTP header/body encoding issues

### DIFF
--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -30,8 +30,8 @@ class HTTPClient(object):
     """
 
     PROTO_RE    = re.compile(r'^[a-z]+://')
-    CONTENT_TYPE_HDR    = u'Content-Type'.encode('us-ascii')
-    CONTENT_LENGTH_HDR  = u'Content-Length'.encode('us-ascii')
+    CONTENT_TYPE_HDR    = b'Content-Type'
+    CONTENT_LENGTH_HDR  = b'Content-Length'
 
     def __init__(self, uri=None, params=None, headers=None, cookies=None,
             auth=None, timeout=None, proxies=None, tls_verify=None,
@@ -299,8 +299,8 @@ class HTTPResponse(object):
 
     def _parse_content_type(self):
         # Handle both cases
-        content_type = self.headers.get('Content-Type', \
-                self.headers.get('content-type'))
+        content_type = self.headers.get(b'Content-Type', \
+                self.headers.get(b'content-type'))
 
         # Is content encoding shoehorned in there?
         if ';' in content_type:

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -30,6 +30,8 @@ class HTTPClient(object):
     """
 
     PROTO_RE    = re.compile(r'^[a-z]+://')
+    CONTENT_TYPE_HDR    = u'Content-Type'.encode('us-ascii')
+    CONTENT_LENGTH_HDR  = u'Content-Length'.encode('us-ascii')
 
     def __init__(self, uri=None, params=None, headers=None, cookies=None,
             auth=None, timeout=None, proxies=None, tls_verify=None,
@@ -226,13 +228,13 @@ class HTTPClient(object):
                 body_size = len(body)
 
             if body_size is not False:
-                headers['Content-Length'] = str(body_size)
+                headers[self.CONTENT_LENGTH_HDR] = str(body_size)
 
             if body_type is not None:
-                headers['Content-Type'] = body_type
+                headers[self.CONTENT_TYPE_HDR] = body_type
 
-        self.request(method='POST', uri=uri, callback=callback, body=body,
-                headers=headers, **kwargs)
+        self.request(method='POST', uri=uri, callback=callback,
+                body=body, headers=headers, **kwargs)
 
     def _request(self, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -315,7 +315,7 @@ class PostGridOperation(BaseGridOperation):
                 session=session, uri=uri, args=args, **kwargs)
 
         # Convert the grids to their native format
-        self._body = hszinc.dump(grid, mode=post_format)
+        self._body = hszinc.dump(grid, mode=post_format).encode('utf-8')
         if post_format == hszinc.MODE_ZINC:
             self._content_type = 'text/zinc'
         else:

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -69,9 +69,9 @@ class BaseGridOperation(state.HaystackOperation):
 
         if not raw_response:
             if expect_format == hszinc.MODE_ZINC:
-                self._headers['Accept'] = 'text/zinc'
+                self._headers[b'Accept'] = 'text/zinc'
             elif expect_format == hszinc.MODE_JSON:
-                self._headers['Accept'] = 'application/json'
+                self._headers[b'Accept'] = 'application/json'
             elif expect_format is not None:
                 raise ValueError(
                         'expect_format must be one onf hszinc.MODE_ZINC '\

--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -53,9 +53,11 @@ class WideskyAuthenticateOperation(state.HaystackOperation):
 
         super(WideskyAuthenticateOperation, self).__init__()
         self._auth_headers = {
-                'Authorization': 'Basic %s' % base64.b64encode(
-                    ':'.join([session._client_id,
-                        session._client_secret]).encode()).decode(),
+                'Authorization': (u'Basic %s' % base64.b64encode(
+                            ':'.join([session._client_id,
+                                session._client_secret]).encode('utf-8')
+                        ).decode('us-ascii')
+                    ).encode('us-ascii'),
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
         }
@@ -63,7 +65,7 @@ class WideskyAuthenticateOperation(state.HaystackOperation):
             'username': session._username,
             'password': session._password,
             'grant_type': 'password',
-        })
+        }).encode('utf-8')
         self._session = session
         self._retries = retries
         self._auth_result = None

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -10,6 +10,17 @@ from .ops.vendor.widesky import WideskyAuthenticateOperation, \
         CreateEntityOperation, WideSkyHasFeaturesOperation
 from .mixins.vendor.widesky import crud, multihis
 
+def _decode_str(s, enc='utf-8'):
+    """
+    Try to decode a 'str' object to a Unicode string.
+    """
+    try:
+        return s.decode(enc)
+    except AttributeError:
+        # This is probably already a Unicode string
+        return s
+
+
 class WideskyHaystackSession(crud.CRUDOpsMixin,
         multihis.MultiHisOpsMixin,
         HaystackSession):
@@ -67,8 +78,10 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
             self._auth_result = operation.result
             self._client.headers = {
                     'Authorization': (u'%s %s' % (
-                        self._auth_result['token_type'].decode('us-ascii'),
-                        self._auth_result['access_token'].decode('us-ascii'),
+                        _decode_str(self._auth_result['token_type'],
+                            'us-ascii'),
+                        _decode_str(self._auth_result['access_token'],
+                            'us-ascii'),
                     )).encode('us-ascii')
             }
         except:

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -66,10 +66,10 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
         try:
             self._auth_result = operation.result
             self._client.headers = {
-                    'Authorization': '%s %s' % (
-                        self._auth_result['token_type'],
-                        self._auth_result['access_token'],
-                    )
+                    'Authorization': (u'%s %s' % (
+                        self._auth_result['token_type'].decode('us-ascii'),
+                        self._auth_result['access_token'].decode('us-ascii'),
+                    )).encode('us-ascii')
             }
         except:
             self._auth_result = None

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -53,7 +53,7 @@ def server_session():
     assert server.requests() == 0, 'More requests waiting'
     rq.respond(status=200,
             headers={
-                'Content-Type': 'application/json'
+                b'Content-Type': 'application/json'
             },
             content='''{
                 "token_type": "Bearer",
@@ -88,7 +88,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/about'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -117,7 +117,7 @@ class TestSession(object):
         })
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -143,7 +143,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/ops'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -189,7 +189,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -215,7 +215,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/formats'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -238,7 +238,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -264,7 +264,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.entity.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -277,7 +277,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -307,7 +307,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Body shall be in ZINC
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single valid grid of this form:
         expected = hszinc.Grid()
@@ -319,12 +319,13 @@ class TestSession(object):
             }, {
                 "id": hszinc.Ref('my.entity.id3'),
         }])
-        actual = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        actual = hszinc.parse(rq.body.decode('utf-8'),
+                mode=hszinc.MODE_ZINC)
         assert len(actual) == 1
         grid_cmp(expected, actual[0])
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -343,7 +344,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done

--- a/tests/client/test_entity.py
+++ b/tests/client/test_entity.py
@@ -54,7 +54,7 @@ def server_session():
     assert server.requests() == 0, 'More requests waiting'
     rq.respond(status=200,
             headers={
-                'Content-Type': 'application/json'
+                b'Content-Type': 'application/json'
             },
             content='''{
                 "token_type": "Bearer",
@@ -91,7 +91,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.entity.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         response = hszinc.Grid()
@@ -106,7 +106,7 @@ class TestSession(object):
         })
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -138,7 +138,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.nonexistent.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with.  Note, server might also choose to
         # throw an error, but we'll pretend it doesn't.
@@ -148,7 +148,7 @@ class TestSession(object):
         response.column['dis'] = {}
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -180,11 +180,11 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        rq_grid = hszinc.parse(rq.body.decode('utf-8'), mode=hszinc.MODE_ZINC)
         assert len(rq_grid) == 1
         rq_grid = rq_grid[0]
 
@@ -221,7 +221,7 @@ class TestSession(object):
             }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -266,11 +266,11 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        rq_grid = hszinc.parse(rq.body.decode('utf-8'), mode=hszinc.MODE_ZINC)
         assert len(rq_grid) == 1
         rq_grid = rq_grid[0]
 
@@ -303,7 +303,7 @@ class TestSession(object):
             }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done


### PR DESCRIPTION
Basically, some versions of `python-requests` get grumpy when confronted with `unicode` objects in Python 2.  This tries to ensure that header names are always US-ASCII and that other fields use appropriate encodings (usually US-ASCII or UTF-8).