### PR TITLE
Proposed updates for release 0.92

### DIFF
--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -30,8 +30,8 @@ class HTTPClient(object):
     """
 
     PROTO_RE    = re.compile(r'^[a-z]+://')
-    CONTENT_TYPE_HDR    = u'Content-Type'.encode('us-ascii')
-    CONTENT_LENGTH_HDR  = u'Content-Length'.encode('us-ascii')
+    CONTENT_TYPE_HDR    = b'Content-Type'
+    CONTENT_LENGTH_HDR  = b'Content-Length'
 
     def __init__(self, uri=None, params=None, headers=None, cookies=None,
             auth=None, timeout=None, proxies=None, tls_verify=None,
@@ -299,8 +299,8 @@ class HTTPResponse(object):
 
     def _parse_content_type(self):
         # Handle both cases
-        content_type = self.headers.get('Content-Type', \
-                self.headers.get('content-type'))
+        content_type = self.headers.get(b'Content-Type', \
+                self.headers.get(b'content-type'))
 
         # Is content encoding shoehorned in there?
         if ';' in content_type:

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -30,6 +30,8 @@ class HTTPClient(object):
     """
 
     PROTO_RE    = re.compile(r'^[a-z]+://')
+    CONTENT_TYPE_HDR    = u'Content-Type'.encode('us-ascii')
+    CONTENT_LENGTH_HDR  = u'Content-Length'.encode('us-ascii')
 
     def __init__(self, uri=None, params=None, headers=None, cookies=None,
             auth=None, timeout=None, proxies=None, tls_verify=None,
@@ -226,13 +228,13 @@ class HTTPClient(object):
                 body_size = len(body)
 
             if body_size is not False:
-                headers['Content-Length'] = str(body_size)
+                headers[self.CONTENT_LENGTH_HDR] = str(body_size)
 
             if body_type is not None:
-                headers['Content-Type'] = body_type
+                headers[self.CONTENT_TYPE_HDR] = body_type
 
-        self.request(method='POST', uri=uri, callback=callback, body=body,
-                headers=headers, **kwargs)
+        self.request(method='POST', uri=uri, callback=callback,
+                body=body, headers=headers, **kwargs)
 
     def _request(self, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -35,7 +35,7 @@ class HTTPClient(object):
 
     def __init__(self, uri=None, params=None, headers=None, cookies=None,
             auth=None, timeout=None, proxies=None, tls_verify=None,
-            tls_cert=None, log=None):
+            tls_cert=None, accept_status=None, log=None):
         """
         Instantiate a HTTP client instance with some default parameters.
         These parameters are made accessible as properties to be modified at
@@ -83,7 +83,8 @@ class HTTPClient(object):
     def request(self, method, uri, callback, body=None, params=None,
             headers=None, cookies=None, auth=None, timeout=None, proxies=None,
             tls_verify=None, tls_cert=None, exclude_params=None,
-            exclude_headers=None, exclude_cookies=None, exclude_proxies=None):
+            exclude_headers=None, exclude_cookies=None, exclude_proxies=None,
+            accept_status=None):
         """
         Perform a request with this client.  Most parameters here exist to either
         add to or override the defaults given by the client attributes.  The
@@ -132,6 +133,10 @@ class HTTPClient(object):
                         If True, exclude all default proxies and use only
                         the proxies given.  Otherwise, this is an iterable
                         of proxy names to be excluded.
+        :param accept_status:
+                        If not None, this gives a list of status codes that
+                        will not raise an error, but instead be passed through
+                        for the Haystack client to handle.
         """
         # Is this an absolute URL?
         if not self.PROTO_RE.match(uri):
@@ -198,7 +203,7 @@ class HTTPClient(object):
         self._request(method=method, uri=uri, callback=callback, body=body,
                 headers=headers, cookies=cookies, auth=auth,
                 timeout=timeout, proxies=proxies, tls_verify=tls_verify,
-                tls_cert=tls_cert)
+                tls_cert=tls_cert, accept_status=accept_status)
 
     def get(self, uri, callback, **kwargs):
         """
@@ -238,7 +243,7 @@ class HTTPClient(object):
 
     def _request(self, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,
-            tls_verify, tls_cert):
+            tls_verify, tls_cert, accept_status):
         """
         Perform a HTTP request using the underlying implementation.  This is
         expected to take the arguments given, perform a query, then return the

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -301,6 +301,8 @@ class HTTPResponse(object):
         # Handle both cases
         content_type = self.headers.get(b'Content-Type', \
                 self.headers.get(b'content-type'))
+        assert content_type is not None, 'Missing content type in %s' \
+                % list(self.headers.keys())
 
         # Is content encoding shoehorned in there?
         if ';' in content_type:

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -259,9 +259,9 @@ class HTTPResponse(object):
     """
     def __init__(self, status_code, headers, body, cookies=None):
         self.status_code = status_code
-        self.headers = headers
+        self.headers = CaseInsensitiveDict(headers)
         self.body = body
-        self.cookies = cookies
+        self.cookies = CaseInsensitiveDict(cookies)
         self._content_type = None
         self._content_type_args = None
         self._text = None
@@ -303,11 +303,7 @@ class HTTPResponse(object):
         return self._text
 
     def _parse_content_type(self):
-        # Handle both cases
-        content_type = self.headers.get(b'Content-Type', \
-                self.headers.get(b'content-type'))
-        assert content_type is not None, 'Missing content type in %s' \
-                % list(self.headers.keys())
+        content_type = self.headers['content-type']
 
         # Is content encoding shoehorned in there?
         if ';' in content_type:
@@ -319,3 +315,30 @@ class HTTPResponse(object):
             content_type_args = {}
         self._content_type = content_type
         self._content_type_args = content_type_args
+
+
+class CaseInsensitiveDict(dict):
+    """
+    A dict object that maps keys in a case-insensitive manner.
+    """
+    def __init__(self, *args, **kwargs):
+        super(CaseInsensitiveDict, self).__init__(*args, **kwargs)
+        self._key_map = dict([(str(k).lower(), k) for k in self.keys()])
+
+    def __getitem__(self, key, *args, **kwargs):
+        try:
+            key = self._key_map[key]
+        except KeyError:
+            pass
+        return super(CaseInsensitiveDict, self).__getitem__(
+                key, *args, **kwargs)
+
+    def __setitem__(self, key, *args, **kwargs):
+        self._key_map[str(key).lower()] = key
+        return super(CaseInsensitiveDict, self).__setitem__(
+                key, *args, **kwargs)
+
+    def __delitem__(self, key, *args, **kwargs):
+        self._key_map.pop(str(key).lower(), None)
+        return super(CaseInsensitiveDict, self).__delitem__(
+                key, *args, **kwargs)

--- a/pyhaystack/client/http/base.py
+++ b/pyhaystack/client/http/base.py
@@ -259,9 +259,9 @@ class HTTPResponse(object):
     """
     def __init__(self, status_code, headers, body, cookies=None):
         self.status_code = status_code
-        self.headers = CaseInsensitiveDict(headers)
+        self.headers = CaseInsensitiveDict(headers or {})
         self.body = body
-        self.cookies = CaseInsensitiveDict(cookies)
+        self.cookies = CaseInsensitiveDict(cookies or {})
         self._content_type = None
         self._content_type_args = None
         self._text = None
@@ -321,20 +321,27 @@ class CaseInsensitiveDict(dict):
     """
     A dict object that maps keys in a case-insensitive manner.
     """
+    @classmethod
+    def _key_to_str(cls, key):
+        # Handle bytes
+        if isinstance(key, bytes):
+            key = key.decode('utf-8')
+        return str(key).lower()
+
     def __init__(self, *args, **kwargs):
         super(CaseInsensitiveDict, self).__init__(*args, **kwargs)
-        self._key_map = dict([(str(k).lower(), k) for k in self.keys()])
+        self._key_map = dict([(self._key_to_str(k), k) for k in self.keys()])
 
     def __getitem__(self, key, *args, **kwargs):
         try:
-            key = self._key_map[key]
+            key = self._key_map[self._key_to_str(key)]
         except KeyError:
             pass
         return super(CaseInsensitiveDict, self).__getitem__(
                 key, *args, **kwargs)
 
     def __setitem__(self, key, *args, **kwargs):
-        self._key_map[str(key).lower()] = key
+        self._key_map[self._key_to_str(k)] = key
         return super(CaseInsensitiveDict, self).__setitem__(
                 key, *args, **kwargs)
 

--- a/pyhaystack/client/http/dummy.py
+++ b/pyhaystack/client/http/dummy.py
@@ -31,7 +31,7 @@ class DummyHttpServer(object):
 
     def submit_request(self, method, uri, callback,
                 body, headers, cookies, auth, timeout, proxies,
-                tls_verify, tls_cert):
+                tls_verify, tls_cert, accept_status):
         """
         Submit a request.
         """
@@ -40,7 +40,7 @@ class DummyHttpServer(object):
 
         rq = DummyHttpClientRequest(rq_id, method, uri, callback,
                 body, headers, cookies, auth, timeout, proxies,
-                tls_verify, tls_cert)
+                tls_verify, tls_cert, accept_status)
         self._requests[rq_id] = rq
         self._rq_order.append(rq_id)
 
@@ -80,10 +80,10 @@ class DummyHttpClient(HTTPClient):
 
     def _request(self, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,
-            tls_verify, tls_cert):
+            tls_verify, tls_cert, accept_status):
         self._server.submit_request(method,
                 uri, callback, body, headers, cookies, auth,
-                timeout, proxies, tls_verify, tls_cert)
+                timeout, proxies, tls_verify, tls_cert, accept_status)
 
 
 class DummyHttpClientRequest(object):
@@ -96,7 +96,7 @@ class DummyHttpClientRequest(object):
 
     def __init__(self, rq_id, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,
-            tls_verify, tls_cert):
+            tls_verify, tls_cert, accept_status):
         """
         Collect all the parameters supplied in the request.
         """
@@ -112,6 +112,7 @@ class DummyHttpClientRequest(object):
         self._proxies = (proxies or {}).copy()
         self._tls_verify = tls_verify
         self._tls_cert = tls_cert
+        self._accept_status = accept_status
 
     # Access methods
 
@@ -185,7 +186,8 @@ class DummyHttpClientRequest(object):
         if cookies is None:
             cookies = {}
 
-        if status < 400:
+        if ((self._accept_status is None) and (status < 400)) \
+                or (status in self._accept_status):
             result = HTTPResponse(status, headers.copy(), content,
                     cookies.copy())
         else:

--- a/pyhaystack/client/http/sync.py
+++ b/pyhaystack/client/http/sync.py
@@ -20,7 +20,7 @@ class SyncHttpClient(HTTPClient):
 
     def _request(self, method, uri, callback, body,
             headers, cookies, auth, timeout, proxies,
-            tls_verify, tls_cert):
+            tls_verify, tls_cert, accept_status):
 
         if auth is not None:
             if isinstance(auth, BasicAuthenticationCredentials):
@@ -44,7 +44,9 @@ class SyncHttpClient(HTTPClient):
                             auth=auth, timeout=timeout,
                             proxies=proxies, verify=tls_verify,
                             cert=tls_cert)
-                    response.raise_for_status()
+                    if (accept_status is None) or \
+                            (response.status_code not in accept_status):
+                        response.raise_for_status()
                 except:
                     if self.log is not None:
                         self.log.debug('Exception in request %s of %s with '\

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -69,9 +69,9 @@ class BaseGridOperation(state.HaystackOperation):
 
         if not raw_response:
             if expect_format == hszinc.MODE_ZINC:
-                self._headers['Accept'] = 'text/zinc'
+                self._headers[b'Accept'] = 'text/zinc'
             elif expect_format == hszinc.MODE_JSON:
-                self._headers['Accept'] = 'application/json'
+                self._headers[b'Accept'] = 'application/json'
             elif expect_format is not None:
                 raise ValueError(
                         'expect_format must be one onf hszinc.MODE_ZINC '\

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -192,6 +192,12 @@ class BaseGridOperation(state.HaystackOperation):
         Process the response given back by the HTTP server.
         """
         try:
+            # Does the session want to invoke any relevant hooks?
+            # This allows a session to detect problems in the session and
+            # abort the operation.
+            if hasattr(self._session, '_on_http_response'):
+                self._session._on_http_response(response)
+
             # Process the HTTP error, if any.
             if isinstance(response, AsynchronousException):
                 response.reraise()

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -23,7 +23,8 @@ class BaseGridOperation(state.HaystackOperation):
 
     def __init__(self, session, uri, args=None,
             expect_format=hszinc.MODE_ZINC, multi_grid=False,
-            raw_response=False, retries=2, cache=False, cache_key=None):
+            raw_response=False, retries=2, cache=False, cache_key=None,
+            accept_status=None):
         """
         Initialise a request for the grid with the given URI and arguments.
 
@@ -43,6 +44,8 @@ class BaseGridOperation(state.HaystackOperation):
         :param cache: Whether or not to cache this result.  If True, the
                       result is cached by the session object.
         :param cache_key: Name of the key to use when the object is cached.
+        :param accept_status: What status codes to accept, in addition to the
+                            usual ones?
         """
 
         super(BaseGridOperation, self).__init__()
@@ -61,6 +64,7 @@ class BaseGridOperation(state.HaystackOperation):
         self._expect_format = expect_format
         self._raw_response = raw_response
         self._headers = {}
+        self._accept_status = accept_status
 
         self._cache = cache
         if cache and (cache_key is None):
@@ -292,7 +296,8 @@ class GetGridOperation(BaseGridOperation):
 
         try:
             self._session._get(self._uri, params=self._args,
-                    headers=self._headers, callback=self._on_response)
+                    headers=self._headers, callback=self._on_response,
+                    accept_status=self._accept_status)
         except: # Catch all exceptions to pass to caller.
             self._log.debug('Get fails', exc_info=1)
             self._state_machine.exception(result=AsynchronousException())
@@ -335,7 +340,8 @@ class PostGridOperation(BaseGridOperation):
         try:
             self._session._post(self._uri, body=self._body,
                     body_type=self._content_type, params=self._args,
-                    headers=self._headers, callback=self._on_response)
+                    headers=self._headers, callback=self._on_response,
+                    accept_status=self._accept_status)
         except: # Catch all exceptions to pass to caller.
             self._log.debug('Post fails', exc_info=1)
             self._state_machine.exception(result=AsynchronousException())

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -195,8 +195,8 @@ class BaseGridOperation(state.HaystackOperation):
             # Does the session want to invoke any relevant hooks?
             # This allows a session to detect problems in the session and
             # abort the operation.
-            if hasattr(self._session, '_on_http_response'):
-                self._session._on_http_response(response)
+            if hasattr(self._session, '_on_http_grid_response'):
+                self._session._on_http_grid_response(response)
 
             # Process the HTTP error, if any.
             if isinstance(response, AsynchronousException):

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -322,7 +322,7 @@ class PostGridOperation(BaseGridOperation):
                 session=session, uri=uri, args=args, **kwargs)
 
         # Convert the grids to their native format
-        self._body = hszinc.dump(grid, mode=post_format)
+        self._body = hszinc.dump(grid, mode=post_format).encode('utf-8')
         if post_format == hszinc.MODE_ZINC:
             self._content_type = 'text/zinc'
         else:

--- a/pyhaystack/client/ops/his.py
+++ b/pyhaystack/client/ops/his.py
@@ -797,33 +797,36 @@ class HisWriteFrameOperation(state.HaystackOperation):
         Return the result from the state machine.
         """
         self._done(event.result)
-        
-class MetaSeries(Series):
-    """
-    Custom Pandas Serie with meta data
-    """
-    meta = {}
-    @property
-    def _constructor(self):
-        return MetaSeries
- 
-    def add_meta(self, key, value):
-        self.meta[key] = value
-        
-class MetaDataFrame(DataFrame):
-    """
-    Custom Pandas Dataframe with meta data
-    Made from MetaSeries
-    """
-    meta = {}
-    def __init__(self, *args, **kw):
-        super(MetaDataFrame, self).__init__(*args, **kw)
- 
-    @property
-    def _constructor(self):
-        return MetaDataFrame
- 
-    _constructor_sliced = MetaSeries
- 
-    def add_meta(self, key, value):
-        self.meta[key] = value
+
+
+if HAVE_PANDAS:
+    class MetaSeries(Series):
+        """
+        Custom Pandas Serie with meta data
+        """
+        meta = {}
+        @property
+        def _constructor(self):
+            return MetaSeries
+
+        def add_meta(self, key, value):
+            self.meta[key] = value
+
+
+    class MetaDataFrame(DataFrame):
+        """
+        Custom Pandas Dataframe with meta data
+        Made from MetaSeries
+        """
+        meta = {}
+        def __init__(self, *args, **kw):
+            super(MetaDataFrame, self).__init__(*args, **kw)
+
+        @property
+        def _constructor(self):
+            return MetaDataFrame
+
+        _constructor_sliced = MetaSeries
+
+        def add_meta(self, key, value):
+            self.meta[key] = value

--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -53,9 +53,11 @@ class WideskyAuthenticateOperation(state.HaystackOperation):
 
         super(WideskyAuthenticateOperation, self).__init__()
         self._auth_headers = {
-                'Authorization': 'Basic %s' % base64.b64encode(
-                    ':'.join([session._client_id,
-                        session._client_secret]).encode()).decode(),
+                'Authorization': (u'Basic %s' % base64.b64encode(
+                            ':'.join([session._client_id,
+                                session._client_secret]).encode('utf-8')
+                        ).decode('us-ascii')
+                    ).encode('us-ascii'),
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
         }
@@ -63,7 +65,7 @@ class WideskyAuthenticateOperation(state.HaystackOperation):
             'username': session._username,
             'password': session._password,
             'grant_type': 'password',
-        })
+        }).encode('utf-8')
         self._session = session
         self._retries = retries
         self._auth_result = None

--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -209,10 +209,15 @@ class WideSkyHasFeaturesOperation(HasFeaturesOperation):
             return res
 
 
-        # Get the WideSky version
-        ver = self._about_data['productVersion']
+        # Get the WideSky version, preferring moduleVersion over productVersion
+        ver = self._about_data.get('moduleVersion',
+                self._about_data['productVersion'])
         for feature in self._features:
             if feature in (HaystackSession.FEATURE_HISREAD_MULTI,
                     HaystackSession.FEATURE_HISWRITE_MULTI):
-                res[feature] = semver.match(ver, '>=0.5.0')
+                try:
+                    res[feature] = semver.match(ver, '>=0.5.0')
+                except ValueError:
+                    # Unrecognised version string
+                    return res
         return res

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -10,6 +10,17 @@ from .ops.vendor.widesky import WideskyAuthenticateOperation, \
         CreateEntityOperation, WideSkyHasFeaturesOperation
 from .mixins.vendor.widesky import crud, multihis
 
+def _decode_str(s, enc='utf-8'):
+    """
+    Try to decode a 'str' object to a Unicode string.
+    """
+    try:
+        return s.decode(enc)
+    except AttributeError:
+        # This is probably already a Unicode string
+        return s
+
+
 class WideskyHaystackSession(crud.CRUDOpsMixin,
         multihis.MultiHisOpsMixin,
         HaystackSession):
@@ -67,8 +78,10 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
             self._auth_result = operation.result
             self._client.headers = {
                     'Authorization': (u'%s %s' % (
-                        self._auth_result['token_type'].decode('us-ascii'),
-                        self._auth_result['access_token'].decode('us-ascii'),
+                        _decode_str(self._auth_result['token_type'],
+                            'us-ascii'),
+                        _decode_str(self._auth_result['access_token'],
+                            'us-ascii'),
                     )).encode('us-ascii')
             }
         except:

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -66,10 +66,10 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
         try:
             self._auth_result = operation.result
             self._client.headers = {
-                    'Authorization': '%s %s' % (
-                        self._auth_result['token_type'],
-                        self._auth_result['access_token'],
-                    )
+                    'Authorization': (u'%s %s' % (
+                        self._auth_result['token_type'].decode('us-ascii'),
+                        self._auth_result['access_token'].decode('us-ascii'),
+                    )).encode('us-ascii')
             }
         except:
             self._auth_result = None

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -69,7 +69,7 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
 
     # Private methods/properties
 
-    def _on_http_response(self, response):
+    def _on_http_grid_response(self, response):
         # If there's a '401' error, then we've lost the token.
         if isinstance(response, AsynchronousException):
             try:

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -9,6 +9,8 @@ from .session import HaystackSession
 from .ops.vendor.widesky import WideskyAuthenticateOperation, \
         CreateEntityOperation, WideSkyHasFeaturesOperation
 from .mixins.vendor.widesky import crud, multihis
+from ..util.asyncexc import AsynchronousException
+from .http.exceptions import HTTPStatusError
 
 def _decode_str(s, enc='utf-8'):
     """
@@ -66,6 +68,24 @@ class WideskyHaystackSession(crud.CRUDOpsMixin,
         return (self._auth_result.get('expires_in') or 0.0) > (1000.0 * time())
 
     # Private methods/properties
+
+    def _on_http_response(self, response):
+        # If there's a '401' error, then we've lost the token.
+        if isinstance(response, AsynchronousException):
+            try:
+                response.reraise()
+            except HTTPStatusError as e:
+                status_code = e.status
+            except:
+                # Anything else, no-op … let the state machine handle it!
+                return
+        else:
+            status_code = response.status_code
+
+        if (status_code == 401) and (self._auth_result is not None):
+            self._log.warning('Authentication lost due to HTTP error 401.')
+            self._auth_result = None
+            self._client.headers = {}
 
     def _on_authenticate_done(self, operation, **kwargs):
         """

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -53,7 +53,7 @@ def server_session():
     assert server.requests() == 0, 'More requests waiting'
     rq.respond(status=200,
             headers={
-                'Content-Type': 'application/json'
+                b'Content-Type': 'application/json'
             },
             content='''{
                 "token_type": "Bearer",
@@ -88,7 +88,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/about'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -117,7 +117,7 @@ class TestSession(object):
         })
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -143,7 +143,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/ops'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -189,7 +189,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -215,7 +215,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/formats'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -238,7 +238,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -264,7 +264,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.entity.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -277,7 +277,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -307,7 +307,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Body shall be in ZINC
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single valid grid of this form:
         expected = hszinc.Grid()
@@ -319,12 +319,13 @@ class TestSession(object):
             }, {
                 "id": hszinc.Ref('my.entity.id3'),
         }])
-        actual = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        actual = hszinc.parse(rq.body.decode('utf-8'),
+                mode=hszinc.MODE_ZINC)
         assert len(actual) == 1
         grid_cmp(expected, actual[0])
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         expected = hszinc.Grid()
@@ -343,7 +344,7 @@ class TestSession(object):
         }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 import pytest
 
 from pyhaystack.client.http import dummy as dummy_http
+from pyhaystack.client.http.base import HTTPResponse
 from ..util import grid_cmp
 
 # For simplicity's sake, we'll just use the WideSky client.
@@ -31,13 +32,28 @@ logging.basicConfig(level=logging.DEBUG)
 
 BASE_URI = 'https://myserver/api/'
 
+# For testing _on_http_grid_response:
+class DummySession(widesky.WideskyHaystackSession):
+    def __init__(self, **kwargs):
+        self._on_http_grid_response_called = 0
+        self._on_http_grid_response_last_args = None
+        super(DummySession, self).__init__(**kwargs)
+
+    def _on_http_grid_response(self, response, *args, **kwargs):
+        self._log.debug(
+                'Received grid response: response=%r args=%r, kwargs=%r',
+                response, args, kwargs)
+        self._on_http_grid_response_called += 1
+        self._on_http_grid_response_last_args = (response, args, kwargs)
+
+
 @pytest.fixture
 def server_session():
     """
     Initialise a HaystackSession and dummy HTTP server instance.
     """
     server = dummy_http.DummyHttpServer()
-    session = widesky.WideskyHaystackSession(
+    session = DummySession(
             uri=BASE_URI,
             username='testuser',
             password='testpassword',
@@ -70,6 +86,40 @@ def server_session():
 
 @pytest.mark.usefixtures("server_session")
 class TestSession(object):
+    def test_on_http_grid_response(self, server_session):
+        (server, session) = server_session
+
+        # Reset our counter
+        session._on_http_grid_response_called = 0
+        session._on_http_grid_response_last_args = None
+
+        # Fetch a grid
+        op = session._get_grid('dummy', callback=lambda *a, **kwa : None)
+
+        # The operation should still be in progress
+        assert not op.is_done
+
+        # There shall be one request
+        assert server.requests() == 1
+        rq = server.next_request()
+        # Make a grid to respond with
+        expected = hszinc.Grid()
+
+        expected.column['empty'] = {}
+        rq.respond(status=200, headers={
+            b'Content-Type': 'text/zinc',
+        }, content=hszinc.dump(expected, mode=hszinc.MODE_ZINC))
+
+        # Our dummy function should have been called
+        assert session._on_http_grid_response_called == 1
+        assert isinstance(session._on_http_grid_response_last_args, tuple)
+        assert len(session._on_http_grid_response_last_args) == 3
+
+        (response, args, kwargs) = session._on_http_grid_response_last_args
+        assert isinstance(response, HTTPResponse)
+        assert len(args) == 0
+        assert len(kwargs) == 0
+
     def test_about(self, server_session):
         (server, session) = server_session
         op = session.about()

--- a/tests/client/test_entity.py
+++ b/tests/client/test_entity.py
@@ -54,7 +54,7 @@ def server_session():
     assert server.requests() == 0, 'More requests waiting'
     rq.respond(status=200,
             headers={
-                'Content-Type': 'application/json'
+                b'Content-Type': 'application/json'
             },
             content='''{
                 "token_type": "Bearer",
@@ -91,7 +91,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.entity.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with
         response = hszinc.Grid()
@@ -106,7 +106,7 @@ class TestSession(object):
         })
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -138,7 +138,7 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read?id=%40my.nonexistent.id'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
 
         # Make a grid to respond with.  Note, server might also choose to
         # throw an error, but we'll pretend it doesn't.
@@ -148,7 +148,7 @@ class TestSession(object):
         response.column['dis'] = {}
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -180,11 +180,11 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        rq_grid = hszinc.parse(rq.body.decode('utf-8'), mode=hszinc.MODE_ZINC)
         assert len(rq_grid) == 1
         rq_grid = rq_grid[0]
 
@@ -221,7 +221,7 @@ class TestSession(object):
             }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done
@@ -266,11 +266,11 @@ class TestSession(object):
         assert rq.uri == BASE_URI + 'api/read'
 
         # Accept header shall be given
-        assert rq.headers['Accept'] == 'text/zinc'
-        assert rq.headers['Content-Type'] == 'text/zinc'
+        assert rq.headers[b'Accept'] == 'text/zinc'
+        assert rq.headers[b'Content-Type'] == 'text/zinc'
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body, mode=hszinc.MODE_ZINC)
+        rq_grid = hszinc.parse(rq.body.decode('utf-8'), mode=hszinc.MODE_ZINC)
         assert len(rq_grid) == 1
         rq_grid = rq_grid[0]
 
@@ -303,7 +303,7 @@ class TestSession(object):
             }])
 
         rq.respond(status=200, headers={
-            'Content-Type': 'text/zinc',
+            b'Content-Type': 'text/zinc',
         }, content=hszinc.dump(response, mode=hszinc.MODE_ZINC))
 
         # State machine should now be done

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -9,6 +9,9 @@ from __future__ import unicode_literals
 import pytest
 
 from pyhaystack.client.http import dummy as dummy_http
+from pyhaystack.client.http.base import HTTPResponse
+from pyhaystack.client.http.exceptions import HTTPStatusError
+from pyhaystack.util.asyncexc import AsynchronousException
 from .util import grid_cmp
 
 from pyhaystack.client import widesky
@@ -110,3 +113,105 @@ class TestIsLoggedIn(object):
 
         # We should see a True result here
         assert session.is_logged_in
+
+
+class TestOnHTTPGridResponse(object):
+    """
+    Test _on_http_grid_response
+    """
+
+    def test_no_op_if_response_not_401(self):
+        """
+        Function does nothing if the response is not a 401 response.
+        """
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Seed this with parameters
+        auth_result = {
+                'expires_in': (time.time() + 3600.0) * 1000.0,
+                'access_token': 'abcdefgh',
+                'refresh_token': '12345678',
+        }
+        session._auth_result = auth_result
+
+        # A dummy response, we don't care much about the content.
+        res = HTTPResponse(status_code=200, headers={}, body='')
+
+        # This should do nothing
+        session._on_http_grid_response(res)
+
+        # Same keys
+        assert set(auth_result.keys()) == set(session._auth_result.keys()), \
+                'Keys mismatch'
+        for key in auth_result.keys():
+            assert auth_result[key] == session._auth_result[key], \
+                    'Mismatching key %s' % key
+
+    def test_logout_if_response_401(self):
+        """
+        Function drops the session if the response is a 401 response.
+        """
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Seed this with parameters
+        auth_result = {
+                'expires_in': (time.time() + 3600.0) * 1000.0,
+                'access_token': 'abcdefgh',
+                'refresh_token': '12345678',
+        }
+        session._auth_result = auth_result
+
+        # A dummy response, we don't care much about the content.
+        res = HTTPResponse(status_code=401, headers={}, body='')
+
+        # This should drop our session
+        session._on_http_grid_response(res)
+        assert session._auth_result is None
+
+    def test_logout_if_response_401_via_exception(self):
+        """
+        Function handles HTTPStatusError with code 401 like a 401 response.
+        """
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Seed this with parameters
+        auth_result = {
+                'expires_in': (time.time() + 3600.0) * 1000.0,
+                'access_token': 'abcdefgh',
+                'refresh_token': '12345678',
+        }
+        session._auth_result = auth_result
+
+        # Generate a HTTPStatusError, wrap it up in an AsynchronousException
+        try:
+            raise HTTPStatusError('Unauthorized', 401)
+        except HTTPStatusError:
+            res = AsynchronousException()
+
+        # This should drop our session
+        session._on_http_grid_response(res)
+        assert session._auth_result is None

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for WideSky session object
+"""
+
+# Assume unicode literals as per Python 3
+from __future__ import unicode_literals
+
+import pytest
+
+from pyhaystack.client.http import dummy as dummy_http
+from .util import grid_cmp
+
+from pyhaystack.client import widesky
+
+# hszinc has its own tests, we'll assume they work
+import hszinc
+
+# For date/time generation
+import datetime
+import pytz
+import time
+
+# Logging setup so we can see what's going on
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+from pyhaystack.client import widesky
+
+BASE_URI = 'https://myserver/api/'
+
+class TestIsLoggedIn(object):
+    """
+    Test is_logged_in property
+    """
+
+    def test_returns_false_if_no_auth_result(self):
+        """
+        is_logged_in == False if _auth_result is None.
+        """
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Straight off the bat, this should be None
+        assert session._auth_result is None
+
+        # Therefore, we should see a False result here
+        assert not session.is_logged_in
+
+    def test_returns_false_if_no_expires_in(self):
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Inject our own auth result, empty dict.
+        session._auth_result = {}
+
+        # We should see a False result here
+        assert not session.is_logged_in
+
+    def test_returns_false_if_expires_in_past(self):
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Inject our own auth result, expiry in the past.
+        session._auth_result = {
+                # Milliseconds here!
+                'expires_in': (time.time() - 1.0) * 1000.0
+        }
+
+        # We should see a False result here
+        assert not session.is_logged_in
+
+    def test_returns_true_if_expires_in_future(self):
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        # Inject our own auth result, expiry in the future.
+        session._auth_result = {
+                # Milliseconds here!
+                'expires_in': (time.time() + 1.0) * 1000.0
+        }
+
+        # We should see a True result here
+        assert session.is_logged_in


### PR DESCRIPTION
Hi Christian,

Just bundled up all the changes that we've got in our fork that have been reviewed here and would like them considered for the next release.

# WC-414: `bytes` vs `unicode` handling.

We were getting error 500s in the API server when attempting to authenticate.  The root cause turned out to be the `bcrypt` Python module generating password hashes that the server didn't like, but this was not before finding numerous issues in Python 2 vs 3 and strings.  (a Python dev favourite!)

The changes have been in production here since September last year, and so far haven't given issues in both Python 2.7 and 3.4.

# FIR-214: `pyhaystack` does not refresh expired token, causing failed writes in AMQP connector

We use `pyhaystack` to bridge between our house-built real-time data collection system (built on Python and using AMQP), and our WideSky system.  We found that if the session token got revoked prematurely for any reason or if the token expired, `pyhaystack` would fail to renew it, and we'd get gaps like this:

https://vrt.on.widesky.cloud/dashboard/db/smartlight?from=1490512025765&to=1490717986116

The changes here allow "whitelisting" of response codes and the handling of the `401: Unauthorized` response to facilitate renewal of the token.  (This may be of help with the SCRAM code in issue #38.)

# `client.ops.his`: Don't define `MetaSeries`/`MetaDataFrame` unless `pandas` loaded

Pandas is great if you're doing advanced numerical analysis, such as what `pyhaystack` was originally written for.  But, it's a big library that drags in `numpy` and on Debian, that often pulls in `matplotlib` and a truck-load of X11-related packages as well.

Much of the time we're dealing with headless devices (sometimes embedded ARM devices with no video hardware whatsoever) and with small amounts of storage.  Every byte counts, so it's helpful to make such features optional.

# WC-9: client.ops.vendor.widesky: Version detection tweaks

After discussion of where and how we'd encode the versions, we ended up making a breaking change.  This moves the location of that check, and also puts some error handling in in case we get something we're not expecting.