### PR TITLE
client.loader: Add support for aliases for known implementations.

### DIFF
--- a/pyhaystack/client/loader.py
+++ b/pyhaystack/client/loader.py
@@ -9,7 +9,17 @@ for fetching session instances.
 from importlib import import_module
 from six import string_types
 
-# KNOWN IMPLEMENTATIONS
+# IMPLEMENTATION ALIASES: These help map short-hand aliases to full session
+# instances.  Further aliases can be added here.
+IMPLEMENTATION_ALIAS = {
+        'niagara-ax':   'niagara.NiagaraHaystackSession',
+        'ax':           'niagara.NiagaraHaystackSession',
+        'skyspark':     'skyspark.SkysparkHaystackSession',
+        'widesky':      'widesky.WideskyHaystackSession',
+}
+
+# KNOWN IMPLEMENTATIONS: This is populated at run time with instances of session
+# classes as they are loaded.  It should be empty at first.
 _known_implementations = {}
 
 def get_implementation(implementation):
@@ -17,6 +27,10 @@ def get_implementation(implementation):
     Get an implementation of Project Haystack session manager based on
     the class name.
     """
+    # De-reference aliases first.
+    if implementation in IMPLEMENTATION_ALIAS:
+        implementation = IMPLEMENTATION_ALIAS[implementation]
+
     try:
         return _known_implementations[implementation]
     except KeyError:


### PR DESCRIPTION
This allows us to whistle up aliases for implementations such as `ax`
for Niagara AX, etc.  Further implementations can be added to this file,
and they will be loaded when needed.