### PR TITLE
Fix PBKDF2 ImportError on Debian Wheezy

### DIFF
--- a/pyhaystack/__init__.py
+++ b/pyhaystack/__init__.py
@@ -2,6 +2,6 @@ try:
     from hszinc import Quantity, use_pint
     Q_ = Quantity
     from .client.loader import get_instance as connect
-    
+
 except ImportError:
     pass

--- a/pyhaystack/client/http/exceptions.py
+++ b/pyhaystack/client/http/exceptions.py
@@ -40,5 +40,5 @@ class HTTPStatusError(HTTPBaseError):
         self.body = body
         self.status = status
         super(HTTPStatusError, self).__init__(message, status)
-        
-    
+
+

--- a/pyhaystack/client/loader.py
+++ b/pyhaystack/client/loader.py
@@ -17,7 +17,7 @@ IMPLEMENTATION_ALIAS = {
         'niagara4':     'niagara.Niagara4HaystackSession',
         'n4':           'niagara.Niagara4HaystackSession',
         'skyspark2':    'skyspark.SkysparkHaystackSession',
-        'skyspark':     'skyspark.SkysparkScramHaystackSession',       
+        'skyspark':     'skyspark.SkysparkScramHaystackSession',
         'widesky':      'widesky.WideskyHaystackSession',
 }
 

--- a/pyhaystack/client/niagara.py
+++ b/pyhaystack/client/niagara.py
@@ -96,7 +96,7 @@ class Niagara4HaystackSession(HaystackSession):
         try:
             op_result = operation.result
             self._authenticated = op_result['authenticated']
-            
+
         except:
             self._authenticated = False
             self._client.auth = None

--- a/pyhaystack/client/ops/entity.py
+++ b/pyhaystack/client/ops/entity.py
@@ -93,8 +93,8 @@ class GetEntityOperation(EntityRetrieveOperation):
     """
     Operation for retrieving entity instances by ID.  This operation peforms
     the following steps::
-    
-        If refresh_all is False:                  
+
+        If refresh_all is False:
         # State: init
             For each entity_id in entity_ids:
                 If entity_id exists in cache:
@@ -102,7 +102,7 @@ class GetEntityOperation(EntityRetrieveOperation):
                     Add entity_id to list got_ids.
             For each entity_id in got_ids:
                 Discard entity_id from entity_ids.
-        If entity_ids is not empty:               
+        If entity_ids is not empty:
         # State: read
             Perform a low-level read of the IDs.
             For each row returned in grid:
@@ -111,11 +111,11 @@ class GetEntityOperation(EntityRetrieveOperation):
                 Else:
                     Update existing Entity instance with new row data.
             Add the new entity instances to cache and store.
-        Return the stored entities.                      
+        Return the stored entities.
         # State: done
 
     """
-    
+
 
     def __init__(self, session, entity_ids, refresh_all, single):
         """
@@ -199,9 +199,9 @@ class FindEntityOperation(EntityRetrieveOperation):
                 Else:
                     Update existing Entity instance with new row data.
                 Add the new entity instances to cache and store.
-            Return the stored entities. 
-            # State: done              
-            
+            Return the stored entities.
+            # State: done
+
     """
 
     def __init__(self, session, filter_expr, limit, single):

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -220,7 +220,6 @@ class BaseGridOperation(state.HaystackOperation):
                 decoded = [hszinc.parse(body, mode=hszinc.MODE_JSON)]
             else:
                 # We don't recognise this!
-                print(body)
                 raise ValueError('Unrecognised content type %s' % content_type)
 
             # Check for exceptions

--- a/pyhaystack/client/ops/his.py
+++ b/pyhaystack/client/ops/his.py
@@ -359,7 +359,7 @@ class HisReadFrameOperation(state.HaystackOperation):
                     """
                     data.add_meta(name,get_units(serie))
                     data[name] = data[name].apply(convert_quantity)
-                    
+
             else:
                 data = self._data_by_ts
             self._state_machine.process_done(result=data)

--- a/pyhaystack/client/ops/vendor/niagara_scram.py
+++ b/pyhaystack/client/ops/vendor/niagara_scram.py
@@ -21,7 +21,7 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
     An implementation of the log-in procedure for Niagara4.  The procedure
     is as follows:
 
-        
+
     1. Log to the prelogin screen and send the username
     2. First Message -> Send an authentication request to the server using the salted user name and a nonce
     3. Second Message -> Send an encoded message that proves we have the password.
@@ -112,31 +112,31 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
                 self._state_machine.do_prelogin()
             else:
                 raise HTTPStatusError("Unable to connect to server")
-            
+
         except Exception as e: # Catch all exceptions to pass to caller.
             self._state_machine.exception(result=AsynchronousException())
 
     def _do_prelogin(self, event):
         """
         Send the username to the prelogin page
-        """     
+        """
         try:
             self._session._post('%s/prelogin' % self._login_uri,
                     params={'j_username': self._session._username},
                     callback=self._on_prelogin,
-                    cookies={}, 
-                    headers={}, 
+                    cookies={},
+                    headers={},
                     exclude_cookies=True,
                     exclude_headers=True, api=False)
 
         except: # Catch all exceptions to pass to caller.
-            pass        
+            pass
 
     def _on_prelogin(self, response):
         """
         Retrieve the log-in parameters.
         """
-        try:       
+        try:
             self._nonce = scram.get_nonce_16()
             self._salt_username = scram.base64_no_padding(self._session._username)
             self.client_first_msg = "n=%s,r=%s" % (self._session._username, self._nonce)
@@ -167,7 +167,7 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
         """
         Retrieve the security parameters from the response.
         This includes the JSESSIONID
-        """        
+        """
         try:
             self.jsession = get_jession(response.headers['set-cookie'])
             self.server_first_msg  = response.body.decode('utf-8')	
@@ -177,9 +177,9 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
             self.server_iterations = scram.regex_after_equal( tab_response[2] )
             self._algorithm_name = "sha256"
             self._algorithm = sha256
-            
+
             self._state_machine.do_second_msg()
-            
+
         except Exception as e:
             self._state_machine.exception(result=AsynchronousException())
 
@@ -189,11 +189,11 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
         Send the client second (final) message to server
         """
         self.salted_password = scram.salted_password_2( self.server_salt, self.server_iterations, self._algorithm_name, self._session._password )
-        client_final_without_proof = "c=%s,r=%s" % ( scram.standard_b64encode(b'n,,').decode(), 
+        client_final_without_proof = "c=%s,r=%s" % ( scram.standard_b64encode(b'n,,').decode(),
                                                     self.server_nonce )
-        self.auth_msg = "%s,%s,%s" % ( self.client_first_msg, self.server_first_msg, 
+        self.auth_msg = "%s,%s,%s" % ( self.client_first_msg, self.server_first_msg,
                                       client_final_without_proof )
-                        
+
         client_proof = _createClientProof(self.salted_password, self.auth_msg, self._algorithm)
         client_final_message = client_final_without_proof + ",p=" + client_proof
         final_msg = 'action=sendClientFinalMessage&clientFinalMessage=%s' % (client_final_message)
@@ -214,18 +214,18 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
         """
         Retrieve the security parameters from the second response.
         We will compare signatures to validate the authentication
-        """        
+        """
         try:
             server_final_message = response.body.decode('utf-8')
             server_key = hmac.new( unhexlify( self.salted_password ), "Server Key".encode('UTF-8'), self._algorithm).hexdigest()
             server_signature = hmac.new( unhexlify( server_key ) , self.auth_msg.encode() , self._algorithm ).hexdigest()
             remote_server_signature = hexlify( scram.b64decode( scram.regex_after_equal( server_final_message ) ) )
-            
+
             if server_signature == remote_server_signature.decode():
                 cookies = dict(JSESSIONID=self.jsession, niagara_userid=self._session._username)
                 self._session._client.cookies = cookies
                 self._state_machine.do_validate_login()
-                          
+
             else:
                 raise Exception('Login Failed, local and remote signature are different')
 
@@ -248,17 +248,17 @@ class Niagara4ScramAuthenticateOperation(state.HaystackOperation):
     def _on_validate_login(self, response):
         """
         Retrieve the response and set authenticated status
-        """        
+        """
         try:
             if response.status_code == 200:
-                self._state_machine.login_done(result={'authenticated': True})                  
+                self._state_machine.login_done(result={'authenticated': True})
             else:
                 raise HTTPStatusError('Server refused the last message')
 
         except Exception as e:
              self._state_machine.exception(result=AsynchronousException())
 
-                  
+
     def _do_fail_retry(self, event):
         """
         Determine whether we retry or fail outright.
@@ -291,7 +291,7 @@ def get_jession(arg_header):
             jsession = scram.regex_after_equal(key)
             jsession = jsession.split(";")[0]
             return jsession
-        
+
 def _createClientProof(salted_password, auth_msg, algorithm):
     client_key          = hmac.new( unhexlify( salted_password ), "Client Key".encode('UTF-8'), algorithm).hexdigest()
     stored_key          = scram._hash_sha256( unhexlify(client_key), algorithm )

--- a/pyhaystack/client/ops/vendor/skyspark.py
+++ b/pyhaystack/client/ops/vendor/skyspark.py
@@ -88,7 +88,7 @@ class SkysparkAuthenticateOperation(state.HaystackOperation):
         try:
             self._session._get(self._login_uri,
                     callback=self._on_new_session,
-                    
+
                     cookies={}, headers={}, exclude_cookies=True,
                     exclude_headers=True, api=False)
                     #args={'username': self._session._username},
@@ -170,22 +170,22 @@ class SkysparkAuthenticateOperation(state.HaystackOperation):
         Return the result from the state machine.
         """
         self._done(event.result)
-        
-def get_digest_info(param):    
+
+def get_digest_info(param):
     message = binary_encoding("%s:%s" % (param['username'], param['userSalt']))
-    password_buf = binary_encoding(param['password']) 
+    password_buf = binary_encoding(param['password'])
     hmac_final = base64.b64encode(hmac.new(key=password_buf, msg=message, digestmod=hashlib.sha1).digest())
-    
+
     digest_msg = binary_encoding('%s:%s' % (hmac_final.decode('utf-8'), param['nonce']))
     digest = hashlib.sha1()
     digest.update(digest_msg)
     digest_final = base64.b64encode((digest.digest()))
-    
+
     res ={'hmac' : hmac_final.decode('utf-8'),
          'digest' : digest_final.decode('utf-8'),
          'nonce' : param['nonce']}
     return res
-    
+
 def binary_encoding(string, encoding = 'utf-8'):
     """
     This helper function will allow compatibility with Python 2 and 3

--- a/pyhaystack/client/session.py
+++ b/pyhaystack/client/session.py
@@ -33,10 +33,10 @@ class HaystackSession(object):
 
     Methods for Haystack operations return an 'Operation' object, which
     may be used in any of two ways:
-    
-    - as a synchronous result placeholder by calling its `wait` method 
+
+    - as a synchronous result placeholder by calling its `wait` method
     followed by inspection of its `result` attribute.
-    - as an asynchronous call manager by connecting a "slot" (`callable` 
+    - as an asynchronous call manager by connecting a "slot" (`callable`
     that takes keyword arguments) to the `done_sig` signal.
 
     The base class takes some arguments that control the default behaviour of
@@ -72,7 +72,7 @@ class HaystackSession(object):
         :param log: Logging object for reporting messages.
         :param pint: Configure hszinc to use basic quantity or Pint Quanity
         :param cache_expiry: Number of seconds before cached data expires.
-        
+
         See : https://pint.readthedocs.io/ for details about pint
         """
         if log is None:
@@ -82,7 +82,7 @@ class HaystackSession(object):
 
         if http_args is None:
             http_args = {}
-        
+
         #Configure hszinc to use pint or not for Quantity definition
         self.config_pint(pint)
 

--- a/pyhaystack/client/skyspark.py
+++ b/pyhaystack/client/skyspark.py
@@ -65,7 +65,7 @@ class SkysparkScramHaystackSession(HaystackSession):
     """
 
     _AUTH_OPERATION = SkysparkScramAuthenticateOperation
-    
+
     def __init__(self, uri, username, password, project, **kwargs):
         """
         Initialise a Skyspark Project Haystack session handler.
@@ -74,7 +74,7 @@ class SkysparkScramHaystackSession(HaystackSession):
         :param username: Authentication user name.
         :param password: Authentication password.
         :param project: Skyspark project name
-        """     
+        """
         super(SkysparkScramHaystackSession, self).__init__(uri,
              'api/%s' % project,**kwargs)
 
@@ -82,7 +82,7 @@ class SkysparkScramHaystackSession(HaystackSession):
         self._password = password
         self._project = project
         self._authenticated = False
-        
+
     @property
     def is_logged_in(self):
         """

--- a/pyhaystack/util/scram.py
+++ b/pyhaystack/util/scram.py
@@ -5,7 +5,15 @@ from binascii import b2a_hex, unhexlify, b2a_base64, hexlify
 from requests.auth import HTTPBasicAuth
 from base64 import standard_b64encode, b64decode, urlsafe_b64encode, \
         urlsafe_b64decode
-from hashlib import sha1, sha256, pbkdf2_hmac
+from hashlib import sha1, sha256
+
+try:
+    # Python 3.4+
+    from hashlib import pbkdf2_hmac
+except ImportError:
+    # Python 3.3 and earlier, needs backports-hashlib.pbkdf2
+    # https://pypi.python.org/pypi/backports.pbkdf2/
+    from backports.pbkdf2 import pbkdf2_hmac
 
 import re
 import os

--- a/pyhaystack/util/scram.py
+++ b/pyhaystack/util/scram.py
@@ -1,3 +1,6 @@
+#!python
+# -*- coding: utf-8 -*-
+
 from binascii import b2a_hex, unhexlify, b2a_base64, hexlify
 from requests.auth import HTTPBasicAuth
 from base64 import standard_b64encode, b64decode, urlsafe_b64encode, urlsafe_b64decode

--- a/pyhaystack/util/scram.py
+++ b/pyhaystack/util/scram.py
@@ -3,7 +3,8 @@
 
 from binascii import b2a_hex, unhexlify, b2a_base64, hexlify
 from requests.auth import HTTPBasicAuth
-from base64 import standard_b64encode, b64decode, urlsafe_b64encode, urlsafe_b64decode
+from base64 import standard_b64encode, b64decode, urlsafe_b64encode, \
+        urlsafe_b64decode
 from hashlib import sha1, sha256, pbkdf2_hmac
 
 import re
@@ -21,12 +22,14 @@ def _hash_sha256(client_key, algorithm):
     return hashFunc.hexdigest()
 
 def salted_password(salt, iterations, algorithm_name, password):
-    dk = pbkdf2_hmac( algorithm_name, password.encode(), urlsafe_b64decode(salt), int(iterations))
+    dk = pbkdf2_hmac(algorithm_name, password.encode(),
+            urlsafe_b64decode(salt), int(iterations))
     encrypt_password = hexlify(dk)
     return encrypt_password
 
 def salted_password_2(salt, iterations, algorithm_name, password):
-    dk = pbkdf2_hmac( algorithm_name, password.encode(), unhexlify(salt), int(iterations))
+    dk = pbkdf2_hmac(algorithm_name, password.encode(),
+            unhexlify(salt), int(iterations))
     encrypt_password = hexlify(dk)
     return encrypt_password
 

--- a/pyhaystack/util/scram.py
+++ b/pyhaystack/util/scram.py
@@ -41,5 +41,3 @@ def regex_after_equal(s):
 
 def _xor(s1, s2):
     return hex(int(s1, 16) ^ int(s2, 16))[2:]
-
-


### PR DESCRIPTION
The new SCRAM code pulls in support for the PBKDF2 HMAC algorithm which although present in Python 3.4+ and some versions of Python 2.7 (evidently, the one used on Travis CI), it isn't universally available on Python 2.7 or earlier releases of 3.x.

As it happens, there's a backport of this feature: https://pypi.python.org/pypi/backports.pbkdf2/

Whilst I'm here, I'm cleaning up an erroneous `print`, some trailing white space, line ending issues and trailing blank lines for neatness. :-)