### PR TITLE
adding refresh functionality in watch_poll which was not implemented …

### DIFF
--- a/pyhaystack/client/session.py
+++ b/pyhaystack/client/session.py
@@ -262,6 +262,10 @@ class HaystackSession(object):
         if not isinstance(watch, string_types):
             watch = watch.id
         grid.metadata['watchId'] = watch
+
+        if refresh:
+            grid.metadata['refresh'] = hszinc.MARKER
+
         return self._post_grid('watchPoll', grid, callback)
 
     def point_write(self, point, level=None, val=None, who=None,


### PR DESCRIPTION
Although the documentation of method `def watch_poll(self, watch, refresh=False, callback=None):` had following text:
`
If refresh is True, then all points on the watch will be updated, not
        just those that have changed since the last poll.
`
, the parameter `refresh` was unused and hence above functionality as stated on documentation wasn't obtained.

I have added following lines to use `refresh` parameter.
```
if refresh:
            grid.metadata['refresh'] = hszinc.MARKER
```