### PR TITLE
cleanup / fix setup.py, and add license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,7 @@ import pyhaystack.info as info
 
 from setuptools import setup
 
-import re
 import os
-import requests
 
 os.environ['COPY_EXTENDED_ATTRIBUTES_DISABLE'] = 'true'
 os.environ['COPYFILE_DISABLE'] = 'true'
@@ -16,12 +14,12 @@ os.environ['COPYFILE_DISABLE'] = 'true'
 
 setup(name='pyhaystack',
       version=info.__version__,
-	 description='Python Haystack Utility',
+      description='Python Haystack Utility',
       author=info.__author__,
       author_email=info.__author_email__,
       url='http://www.project-haystack.com/',
       keywords = ['tags', 'hvac', 'project-haystack', 'building', 'automation', 'analytic'],
-	 install_requires = [
+      install_requires = [
           'requests',
           'setuptools',
           'pandas',
@@ -51,9 +49,6 @@ setup(name='pyhaystack',
           'pyhaystack.util',
           'pyhaystack.server',
           'pyhaystack.util'],
-#      entry_points={
-#          'console_scripts': ['pyhaystack=pyhaystack:main'],
-#     },
       long_description=open('README.rst').read(),
       classifiers=[
           "Development Status :: 4 - Beta",
@@ -63,4 +58,5 @@ setup(name='pyhaystack',
           "Topic :: Software Development :: Libraries :: Python Modules",
           "Topic :: System :: Networking",
           "Topic :: Utilities",
+          "License :: OSI Approved :: Apache Software License",
           ],)


### PR DESCRIPTION
`re` and `requests` weren't used in this file, and weren't declared in
`setup_requires` causing some build issues. Removed these imports.

Removed mixed tabs & spaces.

Explicitly added the Apache License to list of Classifiers so this
project can be identified as Apache Licensed at pypi.org. This matches
the license file.