### PR TITLE
Remove check on raw_request when setting Accept header

### DIFF
--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -24,7 +24,7 @@ class BaseAuthOperation(state.HaystackOperation):
     def __init__(self, session, uri, retries=2, cache=False):
         """
         Initialise a request for the authenticating with the given URI and arguments.
-        
+
         It also contains the state machine for reconnection if needed.
 
         :param session: Haystack HTTP session object.

--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -215,16 +215,15 @@ class BaseGridOperation(BaseAuthOperation):
             cache_key = uri
         self._cache_key = cache_key
 
-        if not raw_response:
-            if expect_format == hszinc.MODE_ZINC:
-                self._headers[b"Accept"] = "text/zinc"
-            elif expect_format == hszinc.MODE_JSON:
-                self._headers[b"Accept"] = "application/json"
-            elif expect_format is not None:
-                raise ValueError(
-                    "expect_format must be one onf hszinc.MODE_ZINC "
-                    "or hszinc.MODE_JSON"
-                )
+        if expect_format == hszinc.MODE_ZINC:
+            self._headers[b"Accept"] = "text/zinc"
+        elif expect_format == hszinc.MODE_JSON:
+            self._headers[b"Accept"] = "application/json"
+        elif expect_format is not None:
+            raise ValueError(
+                "expect_format must be one onf hszinc.MODE_ZINC "
+                "or hszinc.MODE_JSON"
+            )
 
     def _do_check_cache(self, event):
         """


### PR DESCRIPTION
Not sure why the check is there, irrespective of whether we're returning the raw request or not, we should still set the `Accept` header.