### PR TITLE
Fix breakage due to hszinc changes

### DIFF
--- a/pyhaystack/client/ops/grid.py
+++ b/pyhaystack/client/ops/grid.py
@@ -315,11 +315,11 @@ class BaseGridOperation(BaseAuthOperation):
 
             if content_type in ("text/zinc", "text/plain"):
                 # We have been given a grid in ZINC format.
-                decoded = hszinc.parse(body, mode=hszinc.MODE_ZINC)
-            elif content_type == "application/json":
+                decoded = hszinc.parse(body, mode=hszinc.MODE_ZINC, single=False)
+            elif content_type == 'application/json':
                 # We have been given a grid in JSON format.
-                decoded = [hszinc.parse(body, mode=hszinc.MODE_JSON)]
-            elif content_type in ("text/html"):
+                decoded = hszinc.parse(body, mode=hszinc.MODE_JSON, single=False)
+            elif content_type in ('text/html'):
                 # We probably fell back to a login screen after auto logoff.
                 self._state_machine.exception(AsynchronousException())
             else:

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -369,9 +369,9 @@ class TestSession(object):
                 {"id": hszinc.Ref("my.entity.id3")},
             ]
         )
-        actual = hszinc.parse(rq.body.decode("utf-8"), mode=hszinc.MODE_ZINC)
-        assert len(actual) == 1
-        grid_cmp(expected, actual[0])
+        actual = hszinc.parse(rq.body.decode("utf-8"),
+                mode=hszinc.MODE_ZINC, single=True)
+        grid_cmp(expected, actual)
 
         # Accept header shall be given
         assert rq.headers[b"Accept"] == "text/zinc"

--- a/tests/client/test_entity.py
+++ b/tests/client/test_entity.py
@@ -194,9 +194,8 @@ class TestSession(object):
         assert rq.headers[b"Content-Type"] == "text/zinc"
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body.decode("utf-8"), mode=hszinc.MODE_ZINC)
-        assert len(rq_grid) == 1
-        rq_grid = rq_grid[0]
+        rq_grid = hszinc.parse(rq.body.decode("utf-8"),
+                mode=hszinc.MODE_ZINC, single=True)
 
         # It shall have one column; id
         assert set(rq_grid.column.keys()) == set(["id"])
@@ -284,9 +283,8 @@ class TestSession(object):
         assert rq.headers[b"Content-Type"] == "text/zinc"
 
         # Body shall be a single grid:
-        rq_grid = hszinc.parse(rq.body.decode("utf-8"), mode=hszinc.MODE_ZINC)
-        assert len(rq_grid) == 1
-        rq_grid = rq_grid[0]
+        rq_grid = hszinc.parse(rq.body.decode("utf-8"),
+                mode=hszinc.MODE_ZINC, single=True)
 
         # It shall have one column; id
         assert set(rq_grid.column.keys()) == set(["id"])


### PR DESCRIPTION
In `hszinc` 1.3.0, it will by default only return the first grid instead of a list of grid objects when parsing (controlled by the `single` argument).

`pyhaystack` presently assumes it'll get a list of Grid objects if in ZINC mode or a single grid in JSON mode.  This pull request alters this behaviour to always request a multi-grid response, then handle it accordingly.