### PR TITLE
Synchronise changes with WideSky's pyhaystack fork

### DIFF
--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -9,7 +9,7 @@ set -e
 : ${BUILD_PY3:=True}
 
 # Set the output directory if not already given
-: ${OUT_DIR:=${MY_DIR}/out}
+: ${OUT_DIR:=$( realpath "${MY_DIR}/out" )}
 
 cd "${MY_DIR}"
 
@@ -17,15 +17,39 @@ cd "${MY_DIR}"
 [ ! -d deb_dist ] || rm -fr deb_dist
 [ ! -d dist ] || rm -fr dist
 
+# Create working directory
+if [ -z "${WORK_DIR}" ]; then
+	WORK_DIR="$( mktemp -d )"
+	cleanup() {
+		rm -fr "${WORK_DIR}"
+	}
+	trap cleanup EXIT INT QUIT TERM
+fi
+
+# Pick up git tag
+: ${GIT_VERSION:=$( git describe --long )}
+: ${VERSION:=$( echo ${GIT_VERSION} \
+	| sed -e 's/^\([0-9\.]\+\)-\([0-9]\+\)-g.*$/\1.\2/g')}
+
+# Copy to working directory
+tar -C "${MY_DIR}" -cvf - . | tar -C "${WORK_DIR}" -xvf -
+
+# Patch out pandas requirement to reduce our package footprint
+cd "${WORK_DIR}"
+sed -i -e '/install_requires *=/,/packages *=/ { /pandas/ d; }' setup.py
+
 # Build
 "${PYTHON}" setup.py \
 	--command-package stdeb.command sdist_dsc \
 	--with-python2=${BUILD_PY2} --with-python3=${BUILD_PY3} \
+	--forced-upstream-version=${VERSION} \
 	${DEBIAN_VERSION:+--debian-version=}${DEBIAN_VERSION} \
 	--depends python-hszinc --depends3 python3-hszinc \
 	--depends python-signalslot --depends3 python3-signalslot \
+	--build-depends dh-python \
 	--build-depends python-hszinc --build-depends python3-hszinc \
 	--build-depends python-signalslot --build-depends python3-signalslot \
+	--suggests python-pandas --suggests3 python3-pandas \
 	bdist_deb
 
 # Clean up source tree

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -22,6 +22,10 @@ cd "${MY_DIR}"
 	--command-package stdeb.command sdist_dsc \
 	--with-python2=${BUILD_PY2} --with-python3=${BUILD_PY3} \
 	${DEBIAN_VERSION:+--debian-version=}${DEBIAN_VERSION} \
+	--depends python-hszinc --depends3 python3-hszinc \
+	--depends python-signalslot --depends3 python3-signalslot \
+	--build-depends python-hszinc --build-depends python3-hszinc \
+	--build-depends python-signalslot --build-depends python3-signalslot \
 	bdist_deb
 
 # Clean up source tree

--- a/pyhaystack/client/mixins/vendor/widesky/password.py
+++ b/pyhaystack/client/mixins/vendor/widesky/password.py
@@ -4,6 +4,7 @@
 VRT Widesky low-level Password mix-in.
 """
 
+
 class PasswordOpsMixin(object):
     """
     The Password operations mix-in implements low-level support for

--- a/pyhaystack/client/mixins/vendor/widesky/password.py
+++ b/pyhaystack/client/mixins/vendor/widesky/password.py
@@ -1,0 +1,27 @@
+#!python
+# -*- coding: utf-8 -*-
+"""
+VRT Widesky low-level Password mix-in.
+"""
+
+class PasswordOpsMixin(object):
+    """
+    The Password operations mix-in implements low-level support for
+    modifying the current Widesky user's password.
+    """
+
+    def update_password(self, new_password, callback=None):
+        """
+        Change the current logged in user's password.
+
+        If the update is unsuccessful then AsynchronousException is raised.
+
+        :param new_password: Password value.
+        :param callback: The function to call after this operation
+        is complete.
+        """
+        op = self._PASSWORD_CHANGE_OPERATION(self, new_password)
+        if callback is not None:
+            op.done_sig.connect(callback)
+        op.go()
+        return op

--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -249,22 +249,23 @@ class WideSkyPasswordChangeOperation(BaseAuthOperation):
     The Password Change operation implements the logic required to change a
     user's password.
     """
+
     def __init__(self, session, new_password, **kwargs):
         super(WideSkyPasswordChangeOperation, self).__init__(
-                session=session, uri='user/updatePassword', **kwargs
+            session=session, uri="user/updatePassword", **kwargs
         )
         self._new_password = new_password
         self._state_machine = fysom.Fysom(
-                initial='init', final='done',
-                events=[
-                    # Event             Current State       New State
-                    ('send_update',     'init',             'update'),
-                    ('update_done',     'update',           'done'),
-                    ('exception',       '*',                'done'),
-                ], callbacks={
-                    'onsend_update':        self._do_submit,
-                    'onenterdone':          self._do_done,
-                })
+            initial="init",
+            final="done",
+            events=[
+                # Event  Current State  New State
+                ("send_update", "init", "update"),
+                ("update_done", "update", "done"),
+                ("exception", "*", "done"),
+            ],
+            callbacks={"onsend_update": self._do_submit, "onenterdone": self._do_done,},
+        )
 
     def go(self):
         """
@@ -272,7 +273,7 @@ class WideSkyPasswordChangeOperation(BaseAuthOperation):
         """
         try:
             self._state_machine.send_update()
-        except: # Catch all exceptions to pass to caller.
+        except:  # Catch all exceptions to pass to caller.
             self._state_machine.exception(result=AsynchronousException())
 
     def _do_submit(self, event):
@@ -281,15 +282,13 @@ class WideSkyPasswordChangeOperation(BaseAuthOperation):
         """
         try:
             self._session._post(
-                    uri=self._uri,
-                    callback=self._update_done,
-                    body=json.dumps({ "newPassword": self._new_password }),
-                    headers={
-                        "Content-Type": "application/json"
-                    },
-                    api=False
+                uri=self._uri,
+                callback=self._update_done,
+                body=json.dumps({"newPassword": self._new_password}),
+                headers={"Content-Type": "application/json"},
+                api=False,
             )
-        except: # Catch all exceptions to pass to caller.
+        except:  # Catch all exceptions to pass to caller.
             self._state_machine.exception(result=AsynchronousException())
 
     def _update_done(self, response):
@@ -298,7 +297,7 @@ class WideSkyPasswordChangeOperation(BaseAuthOperation):
                 response.reraise()
 
             self._state_machine.update_done(result=None)
-        except: # Catch all exceptions to pass to caller.
+        except:  # Catch all exceptions to pass to caller.
             self._state_machine.exception(result=AsynchronousException())
 
     def _do_done(self, event):

--- a/pyhaystack/client/ops/vendor/widesky.py
+++ b/pyhaystack/client/ops/vendor/widesky.py
@@ -9,11 +9,11 @@ import hszinc
 import fysom
 import json
 import base64
-import shlex
 import semver
 
 from ....util import state
 from ....util.asyncexc import AsynchronousException
+from ..grid import BaseAuthOperation
 from ..entity import EntityRetrieveOperation
 from ..feature import HasFeaturesOperation
 from ...session import HaystackSession
@@ -242,3 +242,67 @@ class WideSkyHasFeaturesOperation(HasFeaturesOperation):
                 except ValueError:
                     return res
         return res
+
+
+class WideSkyPasswordChangeOperation(BaseAuthOperation):
+    """
+    The Password Change operation implements the logic required to change a
+    user's password.
+    """
+    def __init__(self, session, new_password, **kwargs):
+        super(WideSkyPasswordChangeOperation, self).__init__(
+                session=session, uri='user/updatePassword', **kwargs
+        )
+        self._new_password = new_password
+        self._state_machine = fysom.Fysom(
+                initial='init', final='done',
+                events=[
+                    # Event             Current State       New State
+                    ('send_update',     'init',             'update'),
+                    ('update_done',     'update',           'done'),
+                    ('exception',       '*',                'done'),
+                ], callbacks={
+                    'onsend_update':        self._do_submit,
+                    'onenterdone':          self._do_done,
+                })
+
+    def go(self):
+        """
+        Start the request.
+        """
+        try:
+            self._state_machine.send_update()
+        except: # Catch all exceptions to pass to caller.
+            self._state_machine.exception(result=AsynchronousException())
+
+    def _do_submit(self, event):
+        """
+        Change the current logged in user's password.
+        """
+        try:
+            self._session._post(
+                    uri=self._uri,
+                    callback=self._update_done,
+                    body=json.dumps({ "newPassword": self._new_password }),
+                    headers={
+                        "Content-Type": "application/json"
+                    },
+                    api=False
+            )
+        except: # Catch all exceptions to pass to caller.
+            self._state_machine.exception(result=AsynchronousException())
+
+    def _update_done(self, response):
+        try:
+            if isinstance(response, AsynchronousException):
+                response.reraise()
+
+            self._state_machine.update_done(result=None)
+        except: # Catch all exceptions to pass to caller.
+            self._state_machine.exception(result=AsynchronousException())
+
+    def _do_done(self, event):
+        """
+        Return the result from the state machine.
+        """
+        self._done(event.result)

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -49,6 +49,7 @@ class WideskyHaystackSession(
         client_secret,
         api_dir="api",
         auth_dir="oauth2/token",
+        impersonate=None,
         **kwargs
     ):
         """
@@ -59,6 +60,7 @@ class WideskyHaystackSession(
         :param password: Authentication password.
         :param client_id: Authentication client ID.
         :param client_secret: Authentication client secret.
+        :param impersonate: A widesky user ID to impersonate (or None)
         """
         super(WideskyHaystackSession, self).__init__(uri, api_dir, **kwargs)
         self._auth_dir = auth_dir
@@ -67,6 +69,7 @@ class WideskyHaystackSession(
         self._client_id = client_id
         self._client_secret = client_secret
         self._auth_result = None
+        self._impersonate = impersonate
 
     @property
     def is_logged_in(self):
@@ -121,6 +124,9 @@ class WideskyHaystackSession(
                     )
                 ).encode("us-ascii")
             }
+
+            if self._impersonate:
+                self._client.headers['X-IMPERSONATE'] = self._impersonate
         except:
             self._auth_result = None
             self._client.headers = {}

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -10,8 +10,9 @@ from .ops.vendor.widesky import (
     WideskyAuthenticateOperation,
     CreateEntityOperation,
     WideSkyHasFeaturesOperation,
+    WideSkyPasswordChangeOperation,
 )
-from .mixins.vendor.widesky import crud, multihis
+from .mixins.vendor.widesky import crud, multihis, password
 from ..util.asyncexc import AsynchronousException
 from .http.exceptions import HTTPStatusError
 
@@ -28,7 +29,8 @@ def _decode_str(s, enc="utf-8"):
 
 
 class WideskyHaystackSession(
-    crud.CRUDOpsMixin, multihis.MultiHisOpsMixin, HaystackSession
+    crud.CRUDOpsMixin, multihis.MultiHisOpsMixin,
+    password.PasswordOpsMixin, HaystackSession
 ):
     """
     The WideskyHaystackSession class implements some base support for
@@ -39,6 +41,7 @@ class WideskyHaystackSession(
     _AUTH_OPERATION = WideskyAuthenticateOperation
     _CREATE_ENTITY_OPERATION = CreateEntityOperation
     _HAS_FEATURES_OPERATION = WideSkyHasFeaturesOperation
+    _PASSWORD_CHANGE_OPERATION = WideSkyPasswordChangeOperation
 
     def __init__(
         self,

--- a/pyhaystack/client/widesky.py
+++ b/pyhaystack/client/widesky.py
@@ -29,8 +29,10 @@ def _decode_str(s, enc="utf-8"):
 
 
 class WideskyHaystackSession(
-    crud.CRUDOpsMixin, multihis.MultiHisOpsMixin,
-    password.PasswordOpsMixin, HaystackSession
+    crud.CRUDOpsMixin,
+    multihis.MultiHisOpsMixin,
+    password.PasswordOpsMixin,
+    HaystackSession,
 ):
     """
     The WideskyHaystackSession class implements some base support for
@@ -129,7 +131,7 @@ class WideskyHaystackSession(
             }
 
             if self._impersonate:
-                self._client.headers['X-IMPERSONATE'] = self._impersonate
+                self._client.headers["X-IMPERSONATE"] = self._impersonate
         except:
             self._auth_result = None
             self._client.headers = {}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "requests",
         "setuptools",
         "pandas",
-        "parsimonious",
         "iso8601",
         "hszinc",
         "six",

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -124,7 +124,7 @@ class TestUpdatePassword(object):
         rq = server.next_request()
         assert server.requests() == 0, 'More requests waiting'
 
-        assert rq.headers.get('Authorization') == 'Bearer DummyAccessToken'
+        assert rq.headers.get('Authorization') == b'Bearer DummyAccessToken'
         body = json.loads(rq.body)
         assert body == {"newPassword": "hello123X"}
 

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -23,6 +23,9 @@ import hszinc
 import datetime
 import pytz
 import time
+ 
+# JSON encoding/decoding
+import json
 
 # Logging setup so we can see what's going on
 import logging
@@ -40,6 +43,45 @@ class DummyWsOperation(object):
         'access_token': 'abc123',
         'expires_in': (time.time() + 1.0) * 1000.0
     }
+ 
+
+@pytest.fixture
+def server_session():
+    """
+    Initialise a HaystackSession and dummy HTTP server instance.
+    """
+    server = dummy_http.DummyHttpServer()
+    session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True},
+            grid_format=hszinc.MODE_ZINC)
+
+    # Force an authentication.
+    op = session.authenticate()
+
+    # Pop the request off the stack.  We'll assume it's fine for now.
+    rq = server.next_request()
+    assert server.requests() == 0, 'More requests waiting'
+    rq.respond(status=200,
+            headers={
+                b'Content-Type': 'application/json'
+            },
+            content='''{
+                "token_type": "Bearer",
+                "access_token": "DummyAccessToken",
+                "refresh_token": "DummyRefreshToken",
+                "expires_in": %f
+            }''' % ((time.time() + 86400) * 1000.0))
+    assert op.state == 'done'
+    logging.debug('Result = %s', op.result)
+    assert server.requests() == 0
+    assert session.is_logged_in
+    return (server, session)
 
 
 class TestImpersonateParam(object):
@@ -65,6 +107,39 @@ class TestImpersonateParam(object):
         session._on_authenticate_done(DummyWsOperation())
 
         assert session._client.headers['X-IMPERSONATE'] is user_id
+ 
+ 
+class TestUpdatePassword(object):
+    """
+    Test the update_password op
+    """
+
+    def test_update_pwd_endpoint_is_called(self, server_session):
+        (server, session) = server_session
+ 
+        # Issue the request
+        op = session.update_password('hello123X')
+
+        # Pop the request off the stack and inspect it
+        rq = server.next_request()
+        assert server.requests() == 0, 'More requests waiting'
+
+        assert rq.headers.get('Authorization') == 'Bearer DummyAccessToken'
+        body = json.loads(rq.body)
+        assert body == {"newPassword": "hello123X"}
+
+        rq.respond(status=200,
+                headers={
+                    b'Content-Type': 'application/json'
+                },
+                content='{}')
+
+        assert op.state == 'done'
+        logging.debug('Result = %s', op.result)
+        assert server.requests() == 0
+ 
+        op.wait()
+        assert op.result is None
 
 
 class TestIsLoggedIn(object):

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -23,7 +23,7 @@ import hszinc
 import datetime
 import pytz
 import time
- 
+
 # JSON encoding/decoding
 import json
 
@@ -39,11 +39,11 @@ BASE_URI = "https://myserver/api/"
 
 class DummyWsOperation(object):
     result = {
-        'token_type': 'Bearer',
-        'access_token': 'abc123',
-        'expires_in': (time.time() + 1.0) * 1000.0
+        "token_type": "Bearer",
+        "access_token": "abc123",
+        "expires_in": (time.time() + 1.0) * 1000.0,
     }
- 
+
 
 @pytest.fixture
 def server_session():
@@ -52,33 +52,35 @@ def server_session():
     """
     server = dummy_http.DummyHttpServer()
     session = widesky.WideskyHaystackSession(
-            uri=BASE_URI,
-            username='testuser',
-            password='testpassword',
-            client_id='testclient',
-            client_secret='testclientsecret',
-            http_client=dummy_http.DummyHttpClient,
-            http_args={'server': server, 'debug': True},
-            grid_format=hszinc.MODE_ZINC)
+        uri=BASE_URI,
+        username="testuser",
+        password="testpassword",
+        client_id="testclient",
+        client_secret="testclientsecret",
+        http_client=dummy_http.DummyHttpClient,
+        http_args={"server": server, "debug": True},
+        grid_format=hszinc.MODE_ZINC,
+    )
 
     # Force an authentication.
     op = session.authenticate()
 
     # Pop the request off the stack.  We'll assume it's fine for now.
     rq = server.next_request()
-    assert server.requests() == 0, 'More requests waiting'
-    rq.respond(status=200,
-            headers={
-                b'Content-Type': 'application/json'
-            },
-            content='''{
+    assert server.requests() == 0, "More requests waiting"
+    rq.respond(
+        status=200,
+        headers={b"Content-Type": "application/json"},
+        content="""{
                 "token_type": "Bearer",
                 "access_token": "DummyAccessToken",
                 "refresh_token": "DummyRefreshToken",
                 "expires_in": %f
-            }''' % ((time.time() + 86400) * 1000.0))
-    assert op.state == 'done'
-    logging.debug('Result = %s', op.result)
+            }"""
+        % ((time.time() + 86400) * 1000.0),
+    )
+    assert op.state == "done"
+    logging.debug("Result = %s", op.result)
     assert server.requests() == 0
     assert session.is_logged_in
     return (server, session)
@@ -88,27 +90,29 @@ class TestImpersonateParam(object):
     """
     Test is_logged_in property
     """
+
     def test_impersonate_is_set_in_client_header(self):
         """
         is_logged_in == False if _auth_result is None.
         """
-        user_id = '12345ab'
+        user_id = "12345ab"
         server = dummy_http.DummyHttpServer()
         session = widesky.WideskyHaystackSession(
             uri=BASE_URI,
-            username='testuser',
-            password='testpassword',
-            client_id='testclient',
-            client_secret='testclientsecret',
+            username="testuser",
+            password="testpassword",
+            client_id="testclient",
+            client_secret="testclientsecret",
             impersonate=user_id,
             http_client=dummy_http.DummyHttpClient,
-            http_args={'server': server, 'debug': True})
+            http_args={"server": server, "debug": True},
+        )
 
         session._on_authenticate_done(DummyWsOperation())
 
-        assert session._client.headers['X-IMPERSONATE'] is user_id
- 
- 
+        assert session._client.headers["X-IMPERSONATE"] is user_id
+
+
 class TestUpdatePassword(object):
     """
     Test the update_password op
@@ -116,28 +120,26 @@ class TestUpdatePassword(object):
 
     def test_update_pwd_endpoint_is_called(self, server_session):
         (server, session) = server_session
- 
+
         # Issue the request
-        op = session.update_password('hello123X')
+        op = session.update_password("hello123X")
 
         # Pop the request off the stack and inspect it
         rq = server.next_request()
-        assert server.requests() == 0, 'More requests waiting'
+        assert server.requests() == 0, "More requests waiting"
 
-        assert rq.headers.get('Authorization') == b'Bearer DummyAccessToken'
+        assert rq.headers.get("Authorization") == b"Bearer DummyAccessToken"
         body = json.loads(rq.body)
         assert body == {"newPassword": "hello123X"}
 
-        rq.respond(status=200,
-                headers={
-                    b'Content-Type': 'application/json'
-                },
-                content='{}')
+        rq.respond(
+            status=200, headers={b"Content-Type": "application/json"}, content="{}"
+        )
 
-        assert op.state == 'done'
-        logging.debug('Result = %s', op.result)
+        assert op.state == "done"
+        logging.debug("Result = %s", op.result)
         assert server.requests() == 0
- 
+
         op.wait()
         assert op.result is None
 

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -34,6 +34,39 @@ from pyhaystack.client import widesky
 BASE_URI = "https://myserver/api/"
 
 
+class DummyWsOperation(object):
+    result = {
+        'token_type': 'Bearer',
+        'access_token': 'abc123',
+        'expires_in': (time.time() + 1.0) * 1000.0
+    }
+
+
+class TestImpersonateParam(object):
+    """
+    Test is_logged_in property
+    """
+    def test_impersonate_is_set_in_client_header(self):
+        """
+        is_logged_in == False if _auth_result is None.
+        """
+        user_id = '12345ab'
+        server = dummy_http.DummyHttpServer()
+        session = widesky.WideskyHaystackSession(
+            uri=BASE_URI,
+            username='testuser',
+            password='testpassword',
+            client_id='testclient',
+            client_secret='testclientsecret',
+            impersonate=user_id,
+            http_client=dummy_http.DummyHttpClient,
+            http_args={'server': server, 'debug': True})
+
+        session._on_authenticate_done(DummyWsOperation())
+
+        assert session._client.headers['X-IMPERSONATE'] is user_id
+
+
 class TestIsLoggedIn(object):
     """
     Test is_logged_in property


### PR DESCRIPTION
This adds some features from the WideSky fork of `pyhaystack` back to the main-line:

* Fixes to the Debian package builds so that dependencies are respected
* Added support for user password changes using the `updatePassword` API
* Added support for user impersonation for easier authorisation rule debugging by administrators

All code has been passed through the `black` code-reformatter to be consistent with the upstream project.  This PR is a follow-on from PR #94.