### PR TITLE
Clean up differences between WideSky and official pyhaystack trees.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Actually, connection can be established with :
 
 * Niagara4_ by Tridium
 * NiagaraAX_ by Tridium
-* Widesky_ by Widesky.cloud_
+* WideSky_ by Widesky.cloud_
 * Skyspark_ by SkyFoundry (version 2 and 3+)
 
 Connection to Niagara AX or Niagara 4 requires the nHaystack_ module by J2 Innovations to be installed
@@ -123,11 +123,11 @@ to pyhaystack (ex. unit conversion)
 
 .. _Niagara4 : https://www.tridium.com/en/products-services/niagara4
 
-.. _Widesky.cloud : http://widesky.cloud/
+.. _WideSky.cloud : http://widesky.cloud/
 
 .. _Servisys : http://www.servisys.com
 
-.. _Widesky : http://widesky.cloud/ 
+.. _WideSky : http://widesky.cloud/
 
 .. _nHaystack : https://bitbucket.org/jasondbriggs/nhaystack
 

--- a/docs/source/connect.rst
+++ b/docs/source/connect.rst
@@ -349,6 +349,9 @@ arguments are supported:
   WideSky.
 * ``client_secret``: The OAuth2 client secret to use when authenticating with
   WideSky.
+* ``impersonate``: This is an optional parameter. If this is set and the caller
+ has the required permission to act as the target user. Then all subsequent
+ requests coming from this HTTP session will be based on the target user's READ/WRITE permissions.
 
 ``Direct approach``
 ^^^^^^^^^^^^^^^^^^^
@@ -360,7 +363,7 @@ arguments are supported:
                     uri='https://yourtenant.on.widesky.cloud/reference',
                     username='user', password='my_password',
                     client_id='my_id', client_secret='my_secret'
-                    pint=True)
+                    pint=True, impersonate='user_id')
 
 ``connect()`` approach
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -371,8 +374,8 @@ arguments are supported:
     session = pyhaystack.connect(implementation='widesky',
             uri='https://yourtenant.on.widesky.cloud/reference',
             username='user', password='my_password',
-            client_id='my_id', client_secret='my_secret'
-            pint=True)
+            client_id='my_id', client_secret='my_secret',
+            pint=True, impersonate='user_id')
 
 Skyspark
 """"""""

--- a/tests/client/test_entity.py
+++ b/tests/client/test_entity.py
@@ -12,7 +12,6 @@ import pytest
 
 from pyhaystack.client.http import dummy as dummy_http
 from pyhaystack.client.entity.entity import Entity
-from ..util import grid_cmp
 
 # For simplicity's sake, we'll just use the WideSky client.
 # Pretend we're version 0.0.1.
@@ -22,8 +21,6 @@ from pyhaystack.client import widesky
 import hszinc
 
 # For date/time generation
-import datetime
-import pytz
 import time
 
 # Logging setup so we can see what's going on
@@ -242,8 +239,9 @@ class TestSession(object):
         # State machine should now be done
         assert op.is_done
         entities = op.result
+
         # Response should be a dict
-        assert isinstance(entities, dict), "%r not a dict" % entity
+        assert isinstance(entities, dict), "%r not a dict" % entities
         # Response should have these keys
         assert set(entities.keys()) == set(["my.entity.id1", "my.entity.id2"])
 
@@ -331,8 +329,9 @@ class TestSession(object):
         # State machine should now be done
         assert op.is_done
         entities = op.result
+
         # Response should be a dict
-        assert isinstance(entities, dict), "%r not a dict" % entity
+        assert isinstance(entities, dict), "%r not a dict" % entities
         # Response should have these keys
         assert set(entities.keys()) == set(["my.entity.id1", "my.entity.id2"])
 

--- a/tests/test_widesky.py
+++ b/tests/test_widesky.py
@@ -12,7 +12,6 @@ from pyhaystack.client.http import dummy as dummy_http
 from pyhaystack.client.http.base import HTTPResponse
 from pyhaystack.client.http.exceptions import HTTPStatusError
 from pyhaystack.util.asyncexc import AsynchronousException
-from .util import grid_cmp
 
 from pyhaystack.client import widesky
 
@@ -20,8 +19,6 @@ from pyhaystack.client import widesky
 import hszinc
 
 # For date/time generation
-import datetime
-import pytz
 import time
 
 # JSON encoding/decoding
@@ -31,8 +28,6 @@ import json
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
-
-from pyhaystack.client import widesky
 
 BASE_URI = "https://myserver/api/"
 
@@ -113,6 +108,7 @@ class TestImpersonateParam(object):
         assert session._client.headers["X-IMPERSONATE"] is user_id
 
 
+@pytest.mark.usefixtures("server_session")
 class TestUpdatePassword(object):
     """
     Test the update_password op
@@ -123,6 +119,9 @@ class TestUpdatePassword(object):
 
         # Issue the request
         op = session.update_password("hello123X")
+
+        # Make sure there's no error during set-up.
+        assert (not op.is_done) or (op.result is None)
 
         # Pop the request off the stack and inspect it
         rq = server.next_request()


### PR DESCRIPTION
Very minor, this is just cleaning up the `diff` between the two trees… documenting user impersonation (a missed hunk out of the previous change-set), cleaning up some issues that `pyflakes` spotted in the tests, and generally tidying things up for release.